### PR TITLE
Opts file6 remove columns

### DIFF
--- a/src/OptsFile/reader.py
+++ b/src/OptsFile/reader.py
@@ -73,10 +73,11 @@ class Reader(IReader):
             split_option: str = Reader._check_for_tabs(line)
             depth: int = line.count(split_option)
             content: List[str] = line[len(split_option) * depth :].split(" ")
-            if depth == 0 and len(content) == 0:
+            if depth == 0 and len(content) == 1:
                 continue
 
             if len(content) == 1:
+                print(f"{content}")
                 content[0] = Reader._remove_column(content[0])
             
             entries.append(entry(depth, content))

--- a/src/OptsFile/reader.py
+++ b/src/OptsFile/reader.py
@@ -73,6 +73,9 @@ class Reader(IReader):
             split_option: str = Reader._check_for_tabs(line)
             depth: int = line.count(split_option)
             content: List[str] = line[len(split_option) * depth :].split(" ")
+            if depth == 0 and len(content) == 0:
+                continue
+
             if len(content) == 1:
                 content[0] = Reader._remove_column(content[0])
             

--- a/src/OptsFile/reader.py
+++ b/src/OptsFile/reader.py
@@ -73,7 +73,7 @@ class Reader(IReader):
             split_option: str = Reader._check_for_tabs(line)
             depth: int = line.count(split_option)
             content: List[str] = line[len(split_option) * depth :].split(" ")
-            if depth == 0 and len(content) == 1:
+            if depth == 0 and content[0] == "":
                 continue
 
             if len(content) == 1:

--- a/src/OptsFile/reader.py
+++ b/src/OptsFile/reader.py
@@ -73,6 +73,9 @@ class Reader(IReader):
             split_option: str = Reader._check_for_tabs(line)
             depth: int = line.count(split_option)
             content: List[str] = line[len(split_option) * depth :].split(" ")
+            if len(content) == 1:
+                content[0] = Reader._remove_column(content[0])
+            
             entries.append(entry(depth, content))
 
         return entries
@@ -97,6 +100,30 @@ class Reader(IReader):
             raise ReaderError("***ERROR***:\tThe current line seems to be malformed!")
 
         return "\t" if "\t" in line else "    "
+    
+    @staticmethod
+    def _remove_column(content: str) -> str:
+        """
+        This will remove a column from the end of the subcategory line.
+
+        Example:
+            >>> example = "Foo:"
+            >>> Reader._remove_column(example)
+            "Foo"
+
+        Args:
+            content:
+                Category line (will be the only item on the line).
+
+        Returns:
+            content:
+                The modified line (the column stripped).
+        """
+
+        if content[-1] != ":":
+            raise ReaderError("***ERROR***:\tThe current line seems to be malformed!")
+        
+        return content[:-1]
 
     def parse_text(
         self, entries: List[namedtuple], parser: ReadNode

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -31,11 +31,10 @@ def sample_optsfile_text():
 def sample_text_format_output():
     entry = collections.namedtuple("entry", ["depth", "content"])
     return [
-        entry(0, ["Car:"]),
+        entry(0, ["Car"]),
         entry(1, ["Make:", "Honda"]),
         entry(1, ["Model:", "Accord"]),
-        entry(0, [""]),
-        entry(0, ["Bike:"]),
+        entry(0, ["Bike"]),
         entry(1, ["Type:", "Mountain"]),
     ]
 
@@ -71,7 +70,7 @@ def test_reader_format_text(
     entries = Reader._format_text(sample_optsfile_text)
     assert "depth" in entries[0]._fields
     assert "content" in entries[0]._fields
-    assert len(entries) == len(sample_optsfile_text)
+    assert len(entries) == len(sample_optsfile_text) - 1
     for entry1, entry2 in zip(entries, sample_text_format_output):
         assert entry1 == entry2
 
@@ -95,3 +94,21 @@ def test_reader_check_for_tabs(scenario, content, result):
 
     else:
         assert Reader._check_for_tabs(content) == result
+
+@pytest.mark.parametrize(
+    ("scenario", "content", "result"),
+    [
+        ("column", "Line:", "Line"),
+        ("no column", "Line", ""),
+    ]
+)
+def test_reader_remove_column(scenario, content, result):
+    reader = Reader("sample.of")
+    if scenario == "no column":
+        with pytest.raises(ReaderError) as exc:
+            reader._remove_column(content)
+
+        assert exc.value.args[0] == "***ERROR***:\tThe current line seems to be malformed!"
+
+    else:
+        assert reader._remove_column(content) == result


### PR DESCRIPTION
* In order to parse the text appropriately, need to remove `':'` from the end of the subcategory line.
* Implemented `Reader._remove_column` and updated the unit tests to account for this.
* In implementing this fix, found a bug: Would raise an error if the user entered one or more blank lines.
* Added a check to remove any blank lines.
* Updated unit tests for this as well.